### PR TITLE
removing `--pre` option from `pip install`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
 neo4j:
-    image: neo4j/neo4j
+    image: neo4j
     ports: 
-        - "7473:7473"
         - "7474:7474"
+        - "7373:7373"
+        - "7687:7687"
     environment:
-        - NEO4J_NO_AUTH=true
+        - NEO4J_AUTH=none
 
 mongo:
     image: mongo

--- a/mongo_connector/Dockerfile
+++ b/mongo_connector/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-slim
 
-RUN pip install neo4j-doc-manager --pre
+RUN pip install neo4j-doc-manager
 
 ENV MONGO_HOST=localhost MONGO_PORT=27017 NEO4J_HOST=localhost NEO4J_PORT=7474
 


### PR DESCRIPTION
Using the `--pre` option with the `pip install` command within the `mongo_connector` build was causing `neo4j_doc_manager` to install an incompatible version of `py2neo`.