### PR TITLE
Fixed Neo4J & Py2neo version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,25 @@
-neo4j:
-    image: neo4j
-    ports: 
-        - "7474:7474"
-        - "7373:7373"
-        - "7687:7687"
-    environment:
-        - NEO4J_AUTH=none
+version: "3.7"
+services:
+    neo4j:
+        image: neo4j:3.5
+        ports: 
+            - "7474:7474"
+            - "7373:7373"
+            - "7687:7687"
+        environment:
+            - NEO4J_AUTH=none
 
-mongo:
-    image: mongo
-    ports:
-        - "27017:27017"
-    command: mongod --replSet neomongo
+    mongo:
+        image: mongo
+        ports:
+            - "27017:27017"
+        command: mongod --replSet neomongo
 
-mongo_connector:
-    build: ./mongo_connector
-    links:
-        - mongo
-        - neo4j
-    environment:
-        - MONGO_HOST=mongo
-        - NEO4J_HOST=neo4j
+    mongo_connector:
+        build: ./mongo_connector
+        links:
+            - mongo
+            - neo4j
+        environment:
+            - MONGO_HOST=mongo
+            - NEO4J_HOST=neo4j

--- a/mongo_connector/Dockerfile
+++ b/mongo_connector/Dockerfile
@@ -1,6 +1,9 @@
-FROM python:3-slim
+FROM python:3.4-slim
 
-RUN pip install neo4j-doc-manager
+# Use old version of py2eno
+RUN pip install py2neo==2.0.8
+# Use Pre version of Neo4J Doc Manager
+RUN pip install neo4j-doc-manager --pre
 
 ENV MONGO_HOST=localhost MONGO_PORT=27017 NEO4J_HOST=localhost NEO4J_PORT=7474
 


### PR DESCRIPTION
Due to upstream changes, the project was not running anymore.

The solution I found was to fix Python to 3.4 (the version their Travis CI tested for) and Py2neo to 2.0.8 and set the neo4j-doc-manager to the pre version as recommended in the documentation.

There were other changes before but I believe those were out of the scope of this repo